### PR TITLE
fixed missing overlay4.txt file in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ COPY degoo_config/credentials.json /root/.config/degoo/
 COPY degoo_config/default_properties.txt /root/.config/degoo/
 COPY degoo_config/keys.json /root/.config/degoo/
 COPY degoo_config/schedule.json /root/.config/degoo/
+COPY degoo_config/overlay4.txt /root/.config/degoo/overlay4.txt
 
 ENTRYPOINT ["python3.8", "/degoo_drive/fuse_degoo.py"]


### PR DESCRIPTION
overlay4.txt file was not copied over to the container image, resulting in an error.